### PR TITLE
upgrade dependency to luxon 3.2.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ DateTime.fromAny = function fromAny(date, options = {}) {
 	} else if (typeof date === 'number') {
 		return DateTime.fromMillis(date, options);
 	} else if (typeof date === 'object') {
-		return DateTime.fromObject(date);
+		return DateTime.fromObject(date, options);
 	}
 	// String
 	return DateTime.fromHuman(date, options);

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"prettier": "2.5.1"
 			},
 			"peerDependencies": {
-				"luxon": "^1.26.0"
+				"luxon": "^3.2.1"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -3360,12 +3360,12 @@
 			}
 		},
 		"node_modules/luxon": {
-			"version": "1.26.0",
-			"resolved": "https://registry.npmjs.org/luxon/-/luxon-1.26.0.tgz",
-			"integrity": "sha512-+V5QIQ5f6CDXQpWNICELwjwuHdqeJM1UenlZWx5ujcRMc9venvluCjFb4t5NYLhb6IhkbMVOxzVuOqkgMxee2A==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
+			"integrity": "sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg==",
 			"peer": true,
 			"engines": {
-				"node": "*"
+				"node": ">=12"
 			}
 		},
 		"node_modules/make-dir": {
@@ -7057,9 +7057,9 @@
 			}
 		},
 		"luxon": {
-			"version": "1.26.0",
-			"resolved": "https://registry.npmjs.org/luxon/-/luxon-1.26.0.tgz",
-			"integrity": "sha512-+V5QIQ5f6CDXQpWNICELwjwuHdqeJM1UenlZWx5ujcRMc9venvluCjFb4t5NYLhb6IhkbMVOxzVuOqkgMxee2A==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
+			"integrity": "sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg==",
 			"peer": true
 		},
 		"make-dir": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"any-date-parser": "1.5.3"
 	},
 	"peerDependencies": {
-		"luxon": "^1.26.0"
+		"luxon": "^3.2.1"
 	},
 	"devDependencies": {
 		"eslint": "8.7.0",

--- a/test/luxon-parser.spec.js
+++ b/test/luxon-parser.spec.js
@@ -83,6 +83,28 @@ describe('DateTime.fromAny()', () => {
 		const expected = DateTime.fromObject(object);
 		expect(actual.toString()).toBe(expected.toString());
 	});
+	it('should handle object with options', () => {
+		const object = {
+			year: 2021,
+			month: 4,
+			day: 17,
+			hour: 0,
+			minute: 0,
+			second: 0,
+		};
+		const optionsFiji = {
+			zone: 'Pacific/Fiji'
+		};
+		const optionsFaroe = {
+			zone: 'Atlantic/Faroe'
+		};
+		const actualFiji = DateTime.fromAny(object, optionsFiji);
+		const expectedFiji = DateTime.fromObject(object, optionsFiji);
+		expect(actualFiji.toString()).toBe(expectedFiji.toString());
+		const actualFaroe = DateTime.fromAny(object, optionsFaroe);
+		const expectedFaroe = DateTime.fromObject(object, optionsFaroe);
+		expect(actualFaroe.toString()).toBe(expectedFaroe.toString());
+	});
 	it('should default to invalid', () => {
 		const actual = DateTime.fromAny('my toys are sticky');
 		const expected = DateTime.invalid('Unable to parse my toys are sticky');


### PR DESCRIPTION
Hi! I'm working on a project that uses Luxon 3 and I'm hopipng to integrate `luxon-parser` to parse human inputs. In my testing, this package works great with the upgrade, but there's a [signature change](https://github.com/moment/luxon/blob/master/docs/upgrading.md#1x-to-20) in Luxon's `fromObject` method. This PR:

- upgrades the peer dependency
- migrates `fromAny` to use the new signature of `fromObject`
- adds a test using the `zone` option to verify the `options` param is passed through